### PR TITLE
Add coach browsing, coach detail page, and role-based header

### DIFF
--- a/src/components/CoachDashboardView.js
+++ b/src/components/CoachDashboardView.js
@@ -129,7 +129,8 @@ function CoachDashboardView({
                     )}
                     {!req.client.goal &&
                       !req.client.type_workout &&
-                      !req.client.current_activity && (
+                      !req.client.current_activity &&
+                      !req.client.coach_help && (
                         <p className="coach-dash-muted">
                           This client hasn't completed their survey yet.
                         </p>

--- a/src/components/CoachDashboardView.js
+++ b/src/components/CoachDashboardView.js
@@ -1,0 +1,187 @@
+function CoachDashboardView({
+  user,
+  pendingRequests,
+  activeClients,
+  loading,
+  onApprove,
+  onReject,
+  getTimeAgo,
+}) {
+  return (
+    <div className="coach-dash">
+      <div className="coach-dash-header">
+        <div>
+          <h1 className="coach-dash-title">
+            Welcome back, Coach {user?.last_name}
+          </h1>
+          <p className="coach-dash-subtitle">
+            Here's what's happening with your coaching business today.
+          </p>
+        </div>
+
+        <div className="coach-dash-stats">
+          <div className="coach-stat-pill">
+            <span className="coach-stat-num">{pendingRequests.length}</span>
+            <span className="coach-stat-lbl">Pending</span>
+          </div>
+          <div className="coach-stat-pill">
+            <span className="coach-stat-num">{activeClients.length}</span>
+            <span className="coach-stat-lbl">Active Clients</span>
+          </div>
+        </div>
+      </div>
+
+      {/* Pending Requests */}
+      <section className="coach-dash-section">
+        <div className="coach-section-head">
+          <h2>Pending Requests</h2>
+          {pendingRequests.length > 0 && (
+            <span className="coach-badge-red">{pendingRequests.length}</span>
+          )}
+        </div>
+
+        {loading && <p className="coach-dash-muted">Loading requests...</p>}
+
+        {!loading && pendingRequests.length === 0 && (
+          <div className="coach-empty">
+            <div className="coach-empty-icon">📬</div>
+            <h3>No pending requests</h3>
+            <p>New client requests will appear here.</p>
+          </div>
+        )}
+
+        {!loading && pendingRequests.length > 0 && (
+          <div className="coach-req-list">
+            {pendingRequests.map((req) => (
+              <div key={req.relationship_id} className="coach-req-card">
+                <img
+                  src={req.client.profile_pic || "/default-avatar.png"}
+                  alt={req.client.first_name}
+                  className="coach-req-avatar"
+                />
+
+                <div className="coach-req-body">
+                  <div className="coach-req-top">
+                    <div>
+                      <h4 className="coach-req-name">
+                        {req.client.first_name} {req.client.last_name}
+                      </h4>
+                      <p className="coach-req-time">
+                        Requested {getTimeAgo(req.requested_at)}
+                      </p>
+                    </div>
+                    <div className="coach-req-actions">
+                      <button
+                        className="coach-btn-approve"
+                        onClick={() =>
+                          onApprove(req.client.user_id, req.client.first_name)
+                        }
+                      >
+                        Approve
+                      </button>
+                      <button
+                        className="coach-btn-reject"
+                        onClick={() =>
+                          onReject(req.client.user_id, req.client.first_name)
+                        }
+                      >
+                        Reject
+                      </button>
+                    </div>
+                  </div>
+
+                  <div className="coach-req-survey">
+                    {req.client.goal && (
+                      <div className="coach-req-field">
+                        <span className="coach-req-field-label">Goal</span>
+                        <span className="coach-req-field-value">
+                          {req.client.goal}
+                        </span>
+                      </div>
+                    )}
+                    {req.client.type_workout && (
+                      <div className="coach-req-field">
+                        <span className="coach-req-field-label">
+                          Workout Style
+                        </span>
+                        <span className="coach-req-field-value">
+                          {req.client.type_workout}
+                        </span>
+                      </div>
+                    )}
+                    {req.client.current_activity && (
+                      <div className="coach-req-field">
+                        <span className="coach-req-field-label">Activity</span>
+                        <span className="coach-req-field-value">
+                          {req.client.current_activity}
+                        </span>
+                      </div>
+                    )}
+                    {req.client.coach_help && (
+                      <div className="coach-req-field">
+                        <span className="coach-req-field-label">
+                          Looking for
+                        </span>
+                        <span className="coach-req-field-value">
+                          {req.client.coach_help}
+                        </span>
+                      </div>
+                    )}
+                    {!req.client.goal &&
+                      !req.client.type_workout &&
+                      !req.client.current_activity && (
+                        <p className="coach-dash-muted">
+                          This client hasn't completed their survey yet.
+                        </p>
+                      )}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* My Clients */}
+      <section className="coach-dash-section">
+        <div className="coach-section-head">
+          <h2>My Clients</h2>
+        </div>
+
+        {!loading && activeClients.length === 0 && (
+          <div className="coach-empty">
+            <div className="coach-empty-icon">👥</div>
+            <h3>No active clients yet</h3>
+            <p>Approved clients will appear here.</p>
+          </div>
+        )}
+
+        {activeClients.length > 0 && (
+          <div className="coach-clients-grid">
+            {activeClients.map((client) => (
+              <div key={client.user_id} className="coach-client-card">
+                <img
+                  src={client.profile_pic || "/default-avatar.png"}
+                  alt={client.first_name}
+                  className="coach-client-avatar"
+                />
+                <h4>
+                  {client.first_name} {client.last_name}
+                </h4>
+                <p className="coach-client-since">
+                  Client since{" "}
+                  {new Date(client.start_date).toLocaleDateString()}
+                </p>
+                <button className="coach-client-view" disabled>
+                  View Details (coming soon)
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}
+
+export default CoachDashboardView;

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -29,21 +29,37 @@ function Header() {
         <Link to="/dashboard" className="nav-btn">
           Dashboard
         </Link>
-        <Link to="/coach" className="nav-btn">
-          Coach
-        </Link>
-        <Link to="/workouts" className="nav-btn">
-          Workouts
-        </Link>
-        <Link to="/logs" className="nav-btn">
-          Logs
-        </Link>
-        <Link to="/calendar" className="nav-btn">
-          Calendar
-        </Link>
-        <Link to="/payments" className="nav-btn">
-          Payments
-        </Link>
+
+        {activeRole === "client" && (
+          <>
+            <Link to="/coach" className="nav-btn">
+              Coach
+            </Link>
+            <Link to="/workouts" className="nav-btn">
+              Workouts
+            </Link>
+            <Link to="/logs" className="nav-btn">
+              Logs
+            </Link>
+            <Link to="/calendar" className="nav-btn">
+              Calendar
+            </Link>
+            <Link to="/payments" className="nav-btn">
+              Payments
+            </Link>
+          </>
+        )}
+
+        {activeRole === "coach" && (
+          <>
+            <Link to="/workouts" className="nav-btn">
+              Workouts
+            </Link>
+            <Link to="/calendar" className="nav-btn">
+              Schedule
+            </Link>
+          </>
+        )}
       </div>
 
       <div className="right-btns">

--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -10,7 +10,18 @@ export const AuthContext = createContext();
 export const AuthProvider = ({ children }) => {
   const [user, setUser] = useState(null);
   const [loading, setLoading] = useState(true);
-  const [activeRole, setActiveRole] = useState(null);
+  const [activeRole, setActiveRoleState] = useState(
+    localStorage.getItem("activeRole") || null
+  );
+
+  const setActiveRole = (role) => {
+    setActiveRoleState(role);
+    if (role) {
+      localStorage.setItem("activeRole", role);
+    } else {
+      localStorage.removeItem("activeRole");
+    }
+  };
 
   // Fetch user info thorugh the JWT Token
   useEffect(() => {
@@ -47,8 +58,10 @@ export const AuthProvider = ({ children }) => {
   const logout = () => {
     // remove the token from localStorage
     localStorage.removeItem("token");
+    localStorage.removeItem("activeRole");
     // clean the UI
     setUser(null);
+    setActiveRoleState(null);
   };
 
   return (

--- a/src/pages/Coach.js
+++ b/src/pages/Coach.js
@@ -1,81 +1,158 @@
-import React, {useState} from "react";
+import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import "../styles/Coach.css";
 import userimg from "../images/user.svg";
 
-export const coachData=[
-
-];
-
 function Coach() {
+  const [coaches, setCoaches] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
   const [query, setQuery] = useState("");
   const [searchQuery, setSearchQuery] = useState("");
   const [filter, setFilter] = useState("");
   const [roleFilter, setRoleFilter] = useState("coach");
 
+  useEffect(() => {
+    const fetchCoaches = async () => {
+      const token = localStorage.getItem("token");
+      try {
+        const res = await fetch("http://localhost:4000/api/coaches", {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (!res.ok) throw new Error("Failed to load coaches");
+        const data = await res.json();
+        setCoaches(data.data || []);
+      } catch (err) {
+        console.error(err);
+        setError("Could not load coaches. Please try again.");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchCoaches();
+  }, []);
+
   const handleSearch = () => {
     setSearchQuery(query);
   };
 
+  // TODO: wire up nutritionist endpoint when backend supports it
+  const filteredCoaches = coaches.filter((coach) => {
+    // Role filter — only coaches for now; nutritionist returns empty until backend is ready
+    if (roleFilter === "nutritionist") return false;
 
-  const filteredCoaches = coachData.filter((coach) => {
-    const search = searchQuery.toLowerCase();
-    if (coach.role.toLowerCase()!==roleFilter.toLowerCase()){
-      return false;
-    }
     if (!searchQuery) return true;
-    
-    const firstName = `${coach.firstName}`.toLowerCase();
-    const lastName = `${coach.lastName}`.toLowerCase();
-    const specialty = coach.specialty.toLowerCase();
 
+    const search = searchQuery.toLowerCase();
+    const firstName = (coach.first_name || "").toLowerCase();
+    const lastName = (coach.last_name || "").toLowerCase();
+    const specialty = (coach.Coach?.specialization || "").toLowerCase();
 
     if (filter === "name") {
-      return `${coach.firstName} ${coach.lastName}`
-      .toLowerCase()
-      .includes(searchQuery.toLowerCase());
+      return `${firstName} ${lastName}`.includes(search);
     }
 
     if (filter === "specialty") {
-      return coach.specialty
-      .toLowerCase()
-      .includes(searchQuery.toLowerCase());
+      return specialty.includes(search);
     }
 
-    return firstName.includes(search) || lastName.includes(search) || specialty.includes(search);
+    return (
+      firstName.includes(search) ||
+      lastName.includes(search) ||
+      specialty.includes(search)
+    );
   });
 
   return (
     <div>
-    <div className="search-container">
-      <input
-        type="text" placeholder="Search Coach" className="search-input" value={query} onChange={(e) => 
-          setQuery(e.target.value)} />
+      <div className="coach-page-header">
+        <h1>Find Your Coach</h1>
+        <p>
+          Browse our verified coaches and find the perfect match for your goals.
+        </p>
+      </div>
+      <div className="search-container">
+        <input
+          type="text"
+          placeholder="Search Coach"
+          className="search-input"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") handleSearch();
+          }}
+        />
 
-      <select className="filter-dropdown" value={filter} onChange={(e) => setFilter(e.target.value)}>
-        <option value="" disabled>Filter</option>
-        <option value="name">Coach Name</option>
-        <option value="specialty">Specialty</option>
-      </select>
-      <select className="filter-dropdown" value={roleFilter} onChange={(e) => setRoleFilter(e.target.value)}>
-        <option value="coach">Coach</option>
-        <option value="nutritionist">Nutritionist</option>
-      </select>
+        <select
+          className="filter-dropdown"
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+        >
+          <option value="" disabled>
+            Filter
+          </option>
+          <option value="name">Coach Name</option>
+          <option value="specialty">Specialty</option>
+        </select>
 
-      <button className="search-button" onClick={handleSearch}>
-        Search
-      </button>
-    </div>
-    <div className="coach-container">
-      {filteredCoaches.map((coach)=> (
-        <Link key={coach.id} to={`/coach/${coach.id}`} className="coach-card">
-          <img src={userimg} alt={coach.firstName} className="avatar"/>
-          <h3>{coach.firstName} {coach.lastName}</h3>
-          <p>{coach.bio}</p>
-          </Link>
-      )
+        <select
+          className="filter-dropdown"
+          value={roleFilter}
+          onChange={(e) => setRoleFilter(e.target.value)}
+        >
+          <option value="coach">Coach</option>
+          <option value="nutritionist">Nutritionist</option>
+        </select>
+
+        <button className="search-button" onClick={handleSearch}>
+          Search
+        </button>
+      </div>
+
+      {loading && <p className="coach-status">Loading coaches...</p>}
+      {error && <p className="coach-status error">{error}</p>}
+
+      {!loading && !error && filteredCoaches.length === 0 && (
+        <p className="coach-status">
+          {roleFilter === "nutritionist"
+            ? "Nutritionist browsing is coming soon."
+            : "No coaches match your search."}
+        </p>
       )}
-    </div>
+
+      <div className="coach-container">
+        {filteredCoaches.map((coach) => (
+          <Link
+            key={coach.user_id}
+            to={`/coach/${coach.user_id}`}
+            className="coach-card"
+          >
+            <img
+              src={coach.profile_pic || userimg}
+              alt={coach.first_name}
+              className="avatar"
+            />
+            <h3>
+              {coach.first_name} {coach.last_name}
+              {coach.Coach?.is_verified && (
+                <span className="verified-badge">✓</span>
+              )}
+            </h3>
+            <p className="coach-specialty">
+              {coach.Coach?.specialization || "General Coaching"}
+            </p>
+            <p>{coach.Coach?.bio || "No bio available yet."}</p>
+            <div className="coach-card-footer">
+              <span>{coach.Coach?.experience_years || 0} yrs</span>
+              <span className="coach-price">
+                ${coach.Coach?.price || "—"}/hr
+              </span>
+            </div>
+          </Link>
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/pages/CoachDetail.js
+++ b/src/pages/CoachDetail.js
@@ -1,44 +1,386 @@
-import React from "react";
-import { useParams, Link } from "react-router-dom";
+import React, { useContext, useEffect, useState } from "react";
+import { useParams, Link, useNavigate } from "react-router-dom";
 import userimg from "../images/user.svg";
-import { coachData } from "../pages/Coach.js";
+import { AuthContext } from "../context/AuthContext";
 import "../styles/CoachDetail.css";
 
 function CoachDetail() {
   const { id } = useParams();
-  
-  const coach = coachData.find((c) => c.id === parseInt(id));
+  const navigate = useNavigate();
+  const { activeRole } = useContext(AuthContext);
 
-  if (!coach) {
-    return <h2>Coach not found</h2>;
+  const [coach, setCoach] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const [myCoachState, setMyCoachState] = useState(null);
+  const [requesting, setRequesting] = useState(false);
+
+  const [activeTab, setActiveTab] = useState("about");
+
+  useEffect(() => {
+    const fetchCoach = async () => {
+      const token = localStorage.getItem("token");
+      try {
+        const res = await fetch(`http://localhost:4000/api/coaches/${id}`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (res.status === 404) {
+          setError("Coach not found");
+          return;
+        }
+        if (!res.ok) throw new Error("Failed to load coach");
+        const data = await res.json();
+        setCoach(data);
+      } catch (err) {
+        console.error(err);
+        setError("Could not load coach. Please try again.");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchCoach();
+  }, [id]);
+
+  useEffect(() => {
+    if (activeRole !== "client") return;
+
+    const fetchMyCoach = async () => {
+      const token = localStorage.getItem("token");
+      try {
+        const res = await fetch("http://localhost:4000/api/client/my-coach", {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (!res.ok) return;
+        const data = await res.json();
+        setMyCoachState(data.state);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+
+    fetchMyCoach();
+  }, [activeRole]);
+
+  const handleRequest = async () => {
+    if (!window.confirm(`Send a coaching request to ${coach.first_name}?`))
+      return;
+
+    setRequesting(true);
+    const token = localStorage.getItem("token");
+
+    try {
+      const res = await fetch(
+        `http://localhost:4000/api/coaches/${id}/request`,
+        {
+          method: "POST",
+          headers: { Authorization: `Bearer ${token}` },
+        }
+      );
+
+      if (res.status === 409) {
+        const data = await res.json();
+        alert(data.error || "You already have a coach request.");
+        return;
+      }
+
+      if (!res.ok) throw new Error("Failed to send request");
+
+      navigate("/dashboard");
+    } catch (err) {
+      console.error(err);
+      alert("Could not send request. Please try again.");
+    } finally {
+      setRequesting(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="cp-page">
+        <div className="cp-status">Loading...</div>
+      </div>
+    );
   }
 
+  if (error || !coach) {
+    return (
+      <div className="cp-page">
+        <div className="cp-status">
+          <h2>{error || "Coach not found"}</h2>
+          <Link to="/coach" className="cp-back-fallback">
+            ← Back to coaches
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  const canRequest = activeRole === "client" && myCoachState === "none";
+  const requestButtonLabel = (() => {
+    if (activeRole !== "client") return "Only clients can request";
+    if (myCoachState === "pending") return "Request Pending";
+    if (myCoachState === "active") return "You already have a coach";
+    if (requesting) return "Sending...";
+    return "Request this Coach";
+  })();
+
+  // Placeholder package data — wire to backend when session_package / coaching_plan endpoints ship
+  const placeholderPrograms = [
+    {
+      duration: "1 Month",
+      price: 149,
+      features: ["Custom workout plan", "Weekly check-ins", "Chat support"],
+    },
+    {
+      duration: "3 Months",
+      price: 399,
+      features: [
+        "Custom workout plan",
+        "Weekly check-ins",
+        "Chat support",
+        "Nutrition guidance",
+      ],
+      featured: true,
+    },
+    {
+      duration: "6 Months",
+      price: 699,
+      features: [
+        "Everything in 3 Months",
+        "Bi-weekly video calls",
+        "Progress tracking dashboard",
+      ],
+    },
+  ];
+
+  const hourlyRate = coach.Coach?.price || 50;
+
   return (
-    <div className = "coach-detail-page">
+    <div className="cp-page">
+      <Link to="/coach" className="cp-back">
+        ← Back
+      </Link>
 
-    <div className="button-container">
-        <Link to="/coach" className="back-button">
-        <h3>Back</h3>
-        </Link>
-        <button>Coach Information</button>
-        <button>Packages</button>
-        <button>Reviews</button>
-    </div>
+      <div className="cp-container">
+        {/* Header card */}
+        <div className="cp-header-card">
+          <div className="cp-cover"></div>
 
-    <div className="coach-container2">
-        <div className="coach-image">
-            <img src={userimg} alt={coach.firstName} />
+          <div className="cp-header-body">
+            <img
+              src={coach.profile_pic || userimg}
+              alt={coach.first_name}
+              className="cp-avatar"
+            />
+
+            <div className="cp-header-main">
+              <div className="cp-title-row">
+                <div>
+                  <h1 className="cp-name">
+                    {coach.first_name} {coach.last_name}
+                    {coach.Coach?.is_verified && (
+                      <span className="cp-verified">✓ Verified</span>
+                    )}
+                  </h1>
+                  <p className="cp-subtitle">
+                    {coach.Coach?.specialization || "General Coaching"} · Coach
+                  </p>
+                </div>
+
+                <button
+                  className="cp-request-btn"
+                  onClick={handleRequest}
+                  disabled={!canRequest || requesting}
+                >
+                  {requestButtonLabel}
+                </button>
+              </div>
+
+              <div className="cp-stats">
+                <div className="cp-stat">
+                  <span className="cp-stat-value">
+                    {coach.Coach?.experience_years || 0}y
+                  </span>
+                  <span className="cp-stat-label">Experience</span>
+                </div>
+                <div className="cp-stat">
+                  <span className="cp-stat-value">${hourlyRate}</span>
+                  <span className="cp-stat-label">Per hour</span>
+                </div>
+                <div className="cp-stat">
+                  <span className="cp-stat-value">New</span>
+                  <span className="cp-stat-label">Rating</span>
+                </div>
+                <div className="cp-stat">
+                  <span className="cp-stat-value">
+                    {coach.Coach?.is_verified ? "Yes" : "No"}
+                  </span>
+                  <span className="cp-stat-label">Verified</span>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
-        <div className="coach-info">
-            <h2>{coach.firstName} {coach.lastName}</h2>
-            <h4>No Reviews Yet</h4>
-            <p>{coach.bio}</p>
-            <div className="line"></div>
-            <p><strong>Specialty:</strong></p>
-            <p>{coach.specialty}</p>
 
+        {/* Tabs */}
+        <div className="cp-tabs">
+          <button
+            className={`cp-tab ${activeTab === "about" ? "active" : ""}`}
+            onClick={() => setActiveTab("about")}
+          >
+            About
+          </button>
+          <button
+            className={`cp-tab ${activeTab === "packages" ? "active" : ""}`}
+            onClick={() => setActiveTab("packages")}
+          >
+            Packages
+          </button>
+          <button
+            className={`cp-tab ${activeTab === "reviews" ? "active" : ""}`}
+            onClick={() => setActiveTab("reviews")}
+          >
+            Reviews
+          </button>
+          <button
+            className={`cp-tab ${
+              activeTab === "certifications" ? "active" : ""
+            }`}
+            onClick={() => setActiveTab("certifications")}
+          >
+            Certifications
+          </button>
         </div>
-    </div>
+
+        {/* Tab content */}
+        {activeTab === "about" && (
+          <>
+            <div className="cp-card">
+              <h3 className="cp-card-title">Bio</h3>
+              <p className="cp-bio">
+                {coach.Coach?.bio || "This coach hasn't added a bio yet."}
+              </p>
+            </div>
+
+            <div className="cp-card">
+              <h3 className="cp-card-title">Specialization</h3>
+              <div className="cp-chips">
+                <span className="cp-chip">
+                  {coach.Coach?.specialization || "General Coaching"}
+                </span>
+              </div>
+            </div>
+          </>
+        )}
+
+        {activeTab === "packages" && (
+          <>
+            <div className="cp-section-header">
+              <h3>Online Programs</h3>
+              <p>Structured coaching programs with clear milestones.</p>
+            </div>
+
+            <div className="cp-programs-grid">
+              {placeholderPrograms.map((program) => (
+                <div
+                  key={program.duration}
+                  className={`cp-program-card ${
+                    program.featured ? "featured" : ""
+                  }`}
+                >
+                  {program.featured && (
+                    <div className="cp-program-badge">Most Popular</div>
+                  )}
+                  <h4 className="cp-program-title">{program.duration}</h4>
+                  <div className="cp-program-price">
+                    <span className="cp-program-currency">$</span>
+                    {program.price}
+                    <span className="cp-program-period">total</span>
+                  </div>
+                  <ul className="cp-program-features">
+                    {program.features.map((feature) => (
+                      <li key={feature}>{feature}</li>
+                    ))}
+                  </ul>
+                  <button
+                    className="cp-program-btn"
+                    disabled={!canRequest}
+                    onClick={handleRequest}
+                  >
+                    Select Program
+                  </button>
+                </div>
+              ))}
+            </div>
+
+            <div className="cp-section-header">
+              <h3>Book a Session</h3>
+              <p>One-off or bundled sessions at the coach's hourly rate.</p>
+            </div>
+
+            <div className="cp-booking-card">
+              <div className="cp-booking-info">
+                <div className="cp-booking-rate">
+                  <span className="cp-booking-price">${hourlyRate}</span>
+                  <span className="cp-booking-unit">/ hour</span>
+                </div>
+                <p className="cp-booking-desc">
+                  Schedule a single session or buy a bundle (5 or 10 sessions)
+                  at a discount.
+                </p>
+                <div className="cp-booking-bundles">
+                  <div className="cp-bundle">
+                    <span className="cp-bundle-count">1 Session</span>
+                    <span className="cp-bundle-price">${hourlyRate}</span>
+                  </div>
+                  <div className="cp-bundle">
+                    <span className="cp-bundle-count">5 Sessions</span>
+                    <span className="cp-bundle-price">
+                      ${Math.round(hourlyRate * 5 * 0.9)}
+                    </span>
+                    <span className="cp-bundle-save">Save 10%</span>
+                  </div>
+                  <div className="cp-bundle">
+                    <span className="cp-bundle-count">10 Sessions</span>
+                    <span className="cp-bundle-price">
+                      ${Math.round(hourlyRate * 10 * 0.85)}
+                    </span>
+                    <span className="cp-bundle-save">Save 15%</span>
+                  </div>
+                </div>
+              </div>
+              <button
+                className="cp-booking-btn"
+                disabled={!canRequest}
+                onClick={handleRequest}
+              >
+                Book a Session
+              </button>
+            </div>
+          </>
+        )}
+
+        {activeTab === "reviews" && (
+          <div className="cp-card cp-empty">
+            <div className="cp-empty-icon">⭐</div>
+            <h3>No reviews yet</h3>
+            <p>Be the first client to leave a review for {coach.first_name}.</p>
+          </div>
+        )}
+
+        {activeTab === "certifications" && (
+          <div className="cp-card cp-empty">
+            <div className="cp-empty-icon">🎓</div>
+            <h3>No certifications listed</h3>
+            <p>
+              {coach.first_name} hasn't added certifications to their profile
+              yet.
+            </p>
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/pages/Dashboard.js
+++ b/src/pages/Dashboard.js
@@ -15,7 +15,46 @@ import sleepIcon from "../images/sleep.svg";
 import waterIcon from "../images/water.svg";
 
 function Dashboard() {
-  const { user } = useContext(AuthContext);
+  const { user, activeRole } = useContext(AuthContext);
+
+  const [myCoach, setMyCoach] = useState({ state: "loading", coach: null });
+
+  const fetchMyCoach = async () => {
+    const token = localStorage.getItem("token");
+    try {
+      const res = await fetch("http://localhost:4000/api/client/my-coach", {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!res.ok) throw new Error("Failed to load coach!");
+      const data = await res.json();
+      setMyCoach(data);
+    } catch (error) {
+      console.error(error);
+      setMyCoach({ state: "none", coach: null });
+    }
+  };
+
+  useEffect(() => {
+    if (activeRole === "client") {
+      fetchMyCoach();
+    }
+  }, [activeRole]);
+
+  const handleCancelRequest = async () => {
+    if (!window.confirm("Cancel your request to this coach?")) return;
+    const token = localStorage.getItem("token");
+    try {
+      const res = await fetch("http://localhost:4000/api/coaches/request", {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!res.ok && res.status !== 204) throw new Error("Failed to cancel");
+      setMyCoach({ state: "none", coach: null });
+    } catch (error) {
+      console.error(error);
+      alert("Could not cancel request. Try again.");
+    }
+  };
 
   const quickActions = {
     workoutPath: "/workouts",
@@ -172,10 +211,7 @@ function Dashboard() {
   );
 
   const macroTotal =
-    mealTotals.protein +
-    mealTotals.fiber +
-    mealTotals.carbs +
-    mealTotals.fats;
+    mealTotals.protein + mealTotals.fiber + mealTotals.carbs + mealTotals.fats;
 
   const proteinPercent = macroTotal
     ? (mealTotals.protein / macroTotal) * 100
@@ -209,7 +245,7 @@ function Dashboard() {
     });
 
     return Object.values(groupedByDay);
-},    [weightData]);
+  }, [weightData]);
 
   const handleAddWeight = (e) => {
     e.preventDefault();
@@ -258,13 +294,62 @@ function Dashboard() {
       <div className="dashboard-layout">
         <div className="dashboard-left">
           <div className="welcome">Welcome back, {user?.first_name}!</div>
+          {activeRole === "client" && (
+            <section className="dashboard-section">
+              <div className="section-title">My Coach</div>
+              <div className="dashboard-card my-coach-card">
+                {myCoach.state === "loading" && <p>Loading...</p>}
+
+                {myCoach.state === "none" && (
+                  <div className="my-coach-empty">
+                    <p>You don't have a coach yet.</p>
+                    <Link to="/coach" className="dash-btn">
+                      Browse coaches
+                    </Link>
+                  </div>
+                )}
+
+                {(myCoach.state === "pending" || myCoach.state === "active") &&
+                  myCoach.coach && (
+                    <div className="my-coach-info">
+                      <img
+                        src={myCoach.coach.profile_pic || "/default-avatar.png"}
+                        alt={myCoach.coach.first_name}
+                        className="my-coach-avatar"
+                      />
+                      <div className="my-coach-details">
+                        <div className="my-coach-name-row">
+                          <strong>
+                            {myCoach.coach.first_name} {myCoach.coach.last_name}
+                          </strong>
+                          <span className={`my-coach-badge ${myCoach.state}`}>
+                            {myCoach.state === "pending"
+                              ? "Request Pending"
+                              : "Active"}
+                          </span>
+                        </div>
+                        <p className="my-coach-specialization">
+                          {myCoach.coach.specialization}
+                        </p>
+                        {myCoach.state === "pending" && (
+                          <button
+                            onClick={handleCancelRequest}
+                            className="dash-btn cancel-btn"
+                          >
+                            Cancel Request
+                          </button>
+                        )}
+                      </div>
+                    </div>
+                  )}
+              </div>
+            </section>
+          )}
 
           <section className="dashboard-section">
             <div className="section-title">Today's Workout</div>
             <div className="dashboard-card workout-card">
-              <div className="workout-image">
-                
-              </div>
+              <div className="workout-image"></div>
 
               <div className="workout-info">
                 <div className="workout-header-row">
@@ -512,7 +597,12 @@ function Dashboard() {
                       dataKey="value"
                       stroke="#6ca6ff"
                       strokeWidth={3}
-                      dot={{ r: 4, fill: "#6ca6ff", stroke: "#fff", strokeWidth: 2 }}
+                      dot={{
+                        r: 4,
+                        fill: "#6ca6ff",
+                        stroke: "#fff",
+                        strokeWidth: 2,
+                      }}
                       activeDot={{ r: 6 }}
                     />
                   </LineChart>

--- a/src/pages/Dashboard.js
+++ b/src/pages/Dashboard.js
@@ -2,6 +2,7 @@ import React, { useContext, useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import "../styles/Dashboard.css";
 import { AuthContext } from "../context/AuthContext";
+import CoachDashboardView from "../components/CoachDashboardView";
 import {
   LineChart,
   Line,
@@ -100,6 +101,99 @@ function Dashboard() {
   const [calorieGoal, setCalorieGoal] = useState(1750);
   const [activityGoal, setActivityGoal] = useState(120);
   const [activityCurrent, setActivityCurrent] = useState(0);
+  const [pendingRequests, setPendingRequests] = useState([]);
+  const [coachDataLoading, setCoachDataLoading] = useState(false);
+  const [activeClients, setActiveClients] = useState([]);
+
+  const fetchCoachData = async () => {
+    setCoachDataLoading(true);
+    const token = localStorage.getItem("token");
+    try {
+      const [requestsRes, clientsRes] = await Promise.all([
+        fetch("http://localhost:4000/api/coach/requests", {
+          headers: { Authorization: `Bearer ${token}` },
+        }),
+        fetch("http://localhost:4000/api/coach/clients", {
+          headers: { Authorization: `Bearer ${token}` },
+        }),
+      ]);
+
+      if (requestsRes.ok) {
+        const data = await requestsRes.json();
+        setPendingRequests(data.data || []);
+      }
+
+      // clients endpoint is sprint B
+      if (clientsRes.ok) {
+        const data = await clientsRes.json();
+        setActiveClients(data.data || []);
+      } else {
+        setActiveClients([]);
+      }
+    } catch (error) {
+      console.error("Failed to fetch coach data:", error);
+    } finally {
+      setCoachDataLoading(false);
+    }
+  };
+  useEffect(() => {
+    if (activeRole === "coach") {
+      fetchCoachData();
+    }
+  }, [activeRole]);
+
+  const handleApproveRequest = async (clientUserId, clientName) => {
+    if (!window.confirm(`Approve ${clientName} as a client?`)) return;
+    const token = localStorage.getItem("token");
+    try {
+      const res = await fetch(
+        `http://localhost:4000/api/coach/requests/${clientUserId}/approve`,
+        {
+          method: "POST",
+          headers: { Authorization: `Bearer ${token}` },
+        }
+      );
+      if (!res.ok) throw new Error("Failed to approve");
+      fetchCoachData();
+    } catch (err) {
+      console.error(err);
+      alert("Could not approve request. Try again.");
+    }
+  };
+
+  const handleRejectRequest = async (clientUserId, clientName) => {
+    if (!window.confirm(`Reject ${clientName}'s request?`)) return;
+    const token = localStorage.getItem("token");
+    try {
+      const res = await fetch(
+        `http://localhost:4000/api/coach/requests/${clientUserId}/reject`,
+        {
+          method: "POST",
+          headers: { Authorization: `Bearer ${token}` },
+        }
+      );
+      if (!res.ok && res.status !== 204) throw new Error("Failed to reject");
+      fetchCoachData();
+    } catch (err) {
+      console.error(err);
+      alert("Could not reject request. Try again.");
+    }
+  };
+
+  const getTimeAgo = (dateString) => {
+    const now = new Date();
+    const then = new Date(dateString);
+    const diffMs = now - then;
+    const diffMins = Math.floor(diffMs / 60000);
+    const diffHours = Math.floor(diffMs / 3600000);
+    const diffDays = Math.floor(diffMs / 86400000);
+
+    if (diffMins < 1) return "just now";
+    if (diffMins < 60) return `${diffMins}m ago`;
+    if (diffHours < 24) return `${diffHours}h ago`;
+    if (diffDays < 7) return `${diffDays}d ago`;
+    return then.toLocaleDateString();
+  };
 
   useEffect(() => {
     const savedWeightData =
@@ -291,327 +385,343 @@ function Dashboard() {
 
   return (
     <div className="dashboard-page">
-      <div className="dashboard-layout">
-        <div className="dashboard-left">
-          <div className="welcome">Welcome back, {user?.first_name}!</div>
-          {activeRole === "client" && (
-            <section className="dashboard-section">
-              <div className="section-title">My Coach</div>
-              <div className="dashboard-card my-coach-card">
-                {myCoach.state === "loading" && <p>Loading...</p>}
+      {activeRole === "coach" ? (
+        <CoachDashboardView
+          user={user}
+          pendingRequests={pendingRequests}
+          activeClients={activeClients}
+          loading={coachDataLoading}
+          onApprove={handleApproveRequest}
+          onReject={handleRejectRequest}
+          getTimeAgo={getTimeAgo}
+        />
+      ) : (
+        <div className="dashboard-layout">
+          <div className="dashboard-left">
+            <div className="welcome">Welcome back, {user?.first_name}!</div>
+            {activeRole === "client" && (
+              <section className="dashboard-section">
+                <div className="section-title">My Coach</div>
+                <div className="dashboard-card my-coach-card">
+                  {myCoach.state === "loading" && <p>Loading...</p>}
 
-                {myCoach.state === "none" && (
-                  <div className="my-coach-empty">
-                    <p>You don't have a coach yet.</p>
-                    <Link to="/coach" className="dash-btn">
-                      Browse coaches
-                    </Link>
-                  </div>
-                )}
-
-                {(myCoach.state === "pending" || myCoach.state === "active") &&
-                  myCoach.coach && (
-                    <div className="my-coach-info">
-                      <img
-                        src={myCoach.coach.profile_pic || "/default-avatar.png"}
-                        alt={myCoach.coach.first_name}
-                        className="my-coach-avatar"
-                      />
-                      <div className="my-coach-details">
-                        <div className="my-coach-name-row">
-                          <strong>
-                            {myCoach.coach.first_name} {myCoach.coach.last_name}
-                          </strong>
-                          <span className={`my-coach-badge ${myCoach.state}`}>
-                            {myCoach.state === "pending"
-                              ? "Request Pending"
-                              : "Active"}
-                          </span>
-                        </div>
-                        <p className="my-coach-specialization">
-                          {myCoach.coach.specialization}
-                        </p>
-                        {myCoach.state === "pending" && (
-                          <button
-                            onClick={handleCancelRequest}
-                            className="dash-btn cancel-btn"
-                          >
-                            Cancel Request
-                          </button>
-                        )}
-                      </div>
+                  {myCoach.state === "none" && (
+                    <div className="my-coach-empty">
+                      <p>You don't have a coach yet.</p>
+                      <Link to="/coach" className="dash-btn">
+                        Browse coaches
+                      </Link>
                     </div>
                   )}
+
+                  {(myCoach.state === "pending" ||
+                    myCoach.state === "active") &&
+                    myCoach.coach && (
+                      <div className="my-coach-info">
+                        <img
+                          src={
+                            myCoach.coach.profile_pic || "/default-avatar.png"
+                          }
+                          alt={myCoach.coach.first_name}
+                          className="my-coach-avatar"
+                        />
+                        <div className="my-coach-details">
+                          <div className="my-coach-name-row">
+                            <strong>
+                              {myCoach.coach.first_name}{" "}
+                              {myCoach.coach.last_name}
+                            </strong>
+                            <span className={`my-coach-badge ${myCoach.state}`}>
+                              {myCoach.state === "pending"
+                                ? "Request Pending"
+                                : "Active"}
+                            </span>
+                          </div>
+                          <p className="my-coach-specialization">
+                            {myCoach.coach.specialization}
+                          </p>
+                          {myCoach.state === "pending" && (
+                            <button
+                              onClick={handleCancelRequest}
+                              className="dash-btn cancel-btn"
+                            >
+                              Cancel Request
+                            </button>
+                          )}
+                        </div>
+                      </div>
+                    )}
+                </div>
+              </section>
+            )}
+
+            <section className="dashboard-section">
+              <div className="section-title">Today's Workout</div>
+              <div className="dashboard-card workout-card">
+                <div className="workout-image"></div>
+
+                <div className="workout-info">
+                  <div className="workout-header-row">
+                    <div>
+                      <div className="workout-title">{todaysWorkout.title}</div>
+                    </div>
+                    <span className="workout-level">{todaysWorkout.level}</span>
+                  </div>
+
+                  <div className="workout-meta">
+                    <span>{todaysWorkout.duration} min</span>
+                    <span>{todaysWorkout.caloriesBurn} kcal</span>
+                  </div>
+
+                  <div className="workout-footer">
+                    <Link to="/workouts" className="start-workout-btn">
+                      Start Workout
+                    </Link>
+                    <span className="streak-text">
+                      {todaysWorkout.streak} day streak
+                    </span>
+                  </div>
+                </div>
               </div>
             </section>
-          )}
 
-          <section className="dashboard-section">
-            <div className="section-title">Today's Workout</div>
-            <div className="dashboard-card workout-card">
-              <div className="workout-image"></div>
+            <section className="dashboard-section">
+              <div className="dashboard-card quickstart-card">
+                <Link to={quickActions.workoutPath} className="dash-btn">
+                  Start a workout
+                </Link>
+                <Link to={quickActions.mealPath} className="dash-btn">
+                  Log a meal
+                </Link>
+              </div>
+            </section>
 
-              <div className="workout-info">
-                <div className="workout-header-row">
-                  <div>
-                    <div className="workout-title">{todaysWorkout.title}</div>
+            <section className="dashboard-section">
+              <div className="dashboard-card stats-card">
+                <div className="stat-block">
+                  <div className="stat-header">
+                    <span className="stat-title">Calories</span>
+                    <span className="stat-number">
+                      {mealTotals.totalCalories.toLocaleString()}/
+                      {calorieGoal.toLocaleString()}
+                    </span>
                   </div>
-                  <span className="workout-level">{todaysWorkout.level}</span>
-                </div>
 
-                <div className="workout-meta">
-                  <span>{todaysWorkout.duration} min</span>
-                  <span>{todaysWorkout.caloriesBurn} kcal</span>
-                </div>
-
-                <div className="workout-footer">
-                  <Link to="/workouts" className="start-workout-btn">
-                    Start Workout
-                  </Link>
-                  <span className="streak-text">
-                    {todaysWorkout.streak} day streak
-                  </span>
-                </div>
-              </div>
-            </div>
-          </section>
-
-          <section className="dashboard-section">
-            <div className="dashboard-card quickstart-card">
-              <Link to={quickActions.workoutPath} className="dash-btn">
-                Start a workout
-              </Link>
-              <Link to={quickActions.mealPath} className="dash-btn">
-                Log a meal
-              </Link>
-            </div>
-          </section>
-
-          <section className="dashboard-section">
-            <div className="dashboard-card stats-card">
-              <div className="stat-block">
-                <div className="stat-header">
-                  <span className="stat-title">Calories</span>
-                  <span className="stat-number">
-                    {mealTotals.totalCalories.toLocaleString()}/
-                    {calorieGoal.toLocaleString()}
-                  </span>
-                </div>
-
-                <div className="progress-bar">
-                  <div
-                    className="progress-fill"
-                    style={{ width: `${caloriesPercent}%` }}
-                  ></div>
-                </div>
-              </div>
-
-              <div className="stat-block">
-                <div className="stat-header">
-                  <span className="stat-title">Activity Minutes</span>
-                  <span className="stat-number">
-                    {activityCurrent}/{activityGoal}
-                  </span>
-                </div>
-
-                <div className="progress-bar">
-                  <div
-                    className="progress-fill"
-                    style={{ width: `${activityPercent}%` }}
-                  ></div>
-                </div>
-              </div>
-            </div>
-          </section>
-
-          <section className="dashboard-section">
-            <div className="health-row">
-              <div className="health-card">
-                <h4 className="health-title">Sleep</h4>
-                <div className="health-icon">
-                  <img src={sleepIcon} alt="sleep" />
-                </div>
-
-                {editingCard === "sleepHours" ? (
-                  <input
-                    type="number"
-                    name="sleepHours"
-                    value={wellnessInputs.sleepHours}
-                    onChange={handleWellnessInputChange}
-                    onBlur={() => saveWellnessField("sleepHours")}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter") {
-                        saveWellnessField("sleepHours");
-                      }
-                    }}
-                    className="wellness-inline-input"
-                    autoFocus
-                  />
-                ) : (
-                  <p
-                    className="health-value clickable-value"
-                    onClick={() => startEditing("sleepHours")}
-                  >
-                    {wellness.sleepHours} <span>hours</span>
-                  </p>
-                )}
-              </div>
-
-              <div className="health-card">
-                <h4 className="health-title">Water</h4>
-                <div className="health-icon">
-                  <img src={waterIcon} alt="water" />
-                </div>
-
-                {editingCard === "waterCurrent" ? (
-                  <input
-                    type="number"
-                    name="waterCurrent"
-                    value={wellnessInputs.waterCurrent}
-                    onChange={handleWellnessInputChange}
-                    onBlur={() => saveWellnessField("waterCurrent")}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter") {
-                        saveWellnessField("waterCurrent");
-                      }
-                    }}
-                    className="wellness-inline-input"
-                    autoFocus
-                  />
-                ) : (
-                  <p
-                    className="health-value clickable-value"
-                    onClick={() => startEditing("waterCurrent")}
-                  >
-                    {wellness.waterCurrent} <span>ounces</span>
-                  </p>
-                )}
-              </div>
-            </div>
-          </section>
-        </div>
-
-        <div className="dashboard-right">
-          <div className="analytics-row">
-            <div className="widget-card macros-card">
-              <div className="widget-header">
-                <h4>Macros</h4>
-                <span>Today</span>
-              </div>
-
-              <div className="macro-donut-wrap">
-                <div
-                  className="macro-donut"
-                  style={{ background: macrosGradient }}
-                >
-                  <div className="macro-donut-inner">
-                    <span>{mealTotals.totalCalories}</span>
-                  </div>
-                </div>
-              </div>
-
-              <div className="macro-legend">
-                <div className="macro-item">
-                  <span className="macro-dot protein-dot"></span>
-                  <div>
-                    <strong>{mealTotals.protein}g</strong>
-                    <p>Protein</p>
+                  <div className="progress-bar">
+                    <div
+                      className="progress-fill"
+                      style={{ width: `${caloriesPercent}%` }}
+                    ></div>
                   </div>
                 </div>
 
-                <div className="macro-item">
-                  <span className="macro-dot fiber-dot"></span>
-                  <div>
-                    <strong>{mealTotals.fiber}g</strong>
-                    <p>Fiber</p>
+                <div className="stat-block">
+                  <div className="stat-header">
+                    <span className="stat-title">Activity Minutes</span>
+                    <span className="stat-number">
+                      {activityCurrent}/{activityGoal}
+                    </span>
                   </div>
-                </div>
 
-                <div className="macro-item">
-                  <span className="macro-dot carbs-dot"></span>
-                  <div>
-                    <strong>{mealTotals.carbs}g</strong>
-                    <p>Carbs</p>
-                  </div>
-                </div>
-
-                <div className="macro-item">
-                  <span className="macro-dot fats-dot"></span>
-                  <div>
-                    <strong>{mealTotals.fats}g</strong>
-                    <p>Fats</p>
+                  <div className="progress-bar">
+                    <div
+                      className="progress-fill"
+                      style={{ width: `${activityPercent}%` }}
+                    ></div>
                   </div>
                 </div>
               </div>
-            </div>
+            </section>
 
-            <div className="widget-card weight-card">
-              <div className="widget-header">
-                <h4>Weight (lbs)</h4>
-              </div>
+            <section className="dashboard-section">
+              <div className="health-row">
+                <div className="health-card">
+                  <h4 className="health-title">Sleep</h4>
+                  <div className="health-icon">
+                    <img src={sleepIcon} alt="sleep" />
+                  </div>
 
-              <form onSubmit={handleAddWeight} className="dashboard-form">
-                <input
-                  type="number"
-                  step="0.1"
-                  placeholder="Enter weight"
-                  value={weightInput}
-                  onChange={(e) => setWeightInput(e.target.value)}
-                />
-                <button type="submit" className="weight-btn">
-                  Add Weight
-                </button>
-              </form>
-
-              <div className="weight-chart-recharts">
-                <ResponsiveContainer width="100%" height={220}>
-                  <LineChart
-                    data={chartData}
-                    margin={{ top: 10, right: 20, left: 0, bottom: 10 }}
-                  >
-                    <CartesianGrid
-                      stroke="rgba(255,255,255,0.12)"
-                      vertical={false}
-                    />
-
-                    <XAxis
-                      dataKey="day"
-                      tick={{ fill: "#cfd6de", fontSize: 12 }}
-                      axisLine={false}
-                      tickLine={false}
-                    />
-
-                    <YAxis
-                      domain={[
-                        (dataMin) => Math.floor(dataMin - 2),
-                        (dataMax) => Math.ceil(dataMax + 2),
-                      ]}
-                      tick={{ fill: "#cfd6de", fontSize: 12 }}
-                      axisLine={false}
-                      tickLine={false}
-                      width={40}
-                    />
-
-                    <Line
-                      type="monotone"
-                      dataKey="value"
-                      stroke="#6ca6ff"
-                      strokeWidth={3}
-                      dot={{
-                        r: 4,
-                        fill: "#6ca6ff",
-                        stroke: "#fff",
-                        strokeWidth: 2,
+                  {editingCard === "sleepHours" ? (
+                    <input
+                      type="number"
+                      name="sleepHours"
+                      value={wellnessInputs.sleepHours}
+                      onChange={handleWellnessInputChange}
+                      onBlur={() => saveWellnessField("sleepHours")}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") {
+                          saveWellnessField("sleepHours");
+                        }
                       }}
-                      activeDot={{ r: 6 }}
+                      className="wellness-inline-input"
+                      autoFocus
                     />
-                  </LineChart>
-                </ResponsiveContainer>
+                  ) : (
+                    <p
+                      className="health-value clickable-value"
+                      onClick={() => startEditing("sleepHours")}
+                    >
+                      {wellness.sleepHours} <span>hours</span>
+                    </p>
+                  )}
+                </div>
+
+                <div className="health-card">
+                  <h4 className="health-title">Water</h4>
+                  <div className="health-icon">
+                    <img src={waterIcon} alt="water" />
+                  </div>
+
+                  {editingCard === "waterCurrent" ? (
+                    <input
+                      type="number"
+                      name="waterCurrent"
+                      value={wellnessInputs.waterCurrent}
+                      onChange={handleWellnessInputChange}
+                      onBlur={() => saveWellnessField("waterCurrent")}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") {
+                          saveWellnessField("waterCurrent");
+                        }
+                      }}
+                      className="wellness-inline-input"
+                      autoFocus
+                    />
+                  ) : (
+                    <p
+                      className="health-value clickable-value"
+                      onClick={() => startEditing("waterCurrent")}
+                    >
+                      {wellness.waterCurrent} <span>ounces</span>
+                    </p>
+                  )}
+                </div>
+              </div>
+            </section>
+          </div>
+
+          <div className="dashboard-right">
+            <div className="analytics-row">
+              <div className="widget-card macros-card">
+                <div className="widget-header">
+                  <h4>Macros</h4>
+                  <span>Today</span>
+                </div>
+
+                <div className="macro-donut-wrap">
+                  <div
+                    className="macro-donut"
+                    style={{ background: macrosGradient }}
+                  >
+                    <div className="macro-donut-inner">
+                      <span>{mealTotals.totalCalories}</span>
+                    </div>
+                  </div>
+                </div>
+
+                <div className="macro-legend">
+                  <div className="macro-item">
+                    <span className="macro-dot protein-dot"></span>
+                    <div>
+                      <strong>{mealTotals.protein}g</strong>
+                      <p>Protein</p>
+                    </div>
+                  </div>
+
+                  <div className="macro-item">
+                    <span className="macro-dot fiber-dot"></span>
+                    <div>
+                      <strong>{mealTotals.fiber}g</strong>
+                      <p>Fiber</p>
+                    </div>
+                  </div>
+
+                  <div className="macro-item">
+                    <span className="macro-dot carbs-dot"></span>
+                    <div>
+                      <strong>{mealTotals.carbs}g</strong>
+                      <p>Carbs</p>
+                    </div>
+                  </div>
+
+                  <div className="macro-item">
+                    <span className="macro-dot fats-dot"></span>
+                    <div>
+                      <strong>{mealTotals.fats}g</strong>
+                      <p>Fats</p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <div className="widget-card weight-card">
+                <div className="widget-header">
+                  <h4>Weight (lbs)</h4>
+                </div>
+
+                <form onSubmit={handleAddWeight} className="dashboard-form">
+                  <input
+                    type="number"
+                    step="0.1"
+                    placeholder="Enter weight"
+                    value={weightInput}
+                    onChange={(e) => setWeightInput(e.target.value)}
+                  />
+                  <button type="submit" className="weight-btn">
+                    Add Weight
+                  </button>
+                </form>
+
+                <div className="weight-chart-recharts">
+                  <ResponsiveContainer width="100%" height={220}>
+                    <LineChart
+                      data={chartData}
+                      margin={{ top: 10, right: 20, left: 0, bottom: 10 }}
+                    >
+                      <CartesianGrid
+                        stroke="rgba(255,255,255,0.12)"
+                        vertical={false}
+                      />
+
+                      <XAxis
+                        dataKey="day"
+                        tick={{ fill: "#cfd6de", fontSize: 12 }}
+                        axisLine={false}
+                        tickLine={false}
+                      />
+
+                      <YAxis
+                        domain={[
+                          (dataMin) => Math.floor(dataMin - 2),
+                          (dataMax) => Math.ceil(dataMax + 2),
+                        ]}
+                        tick={{ fill: "#cfd6de", fontSize: 12 }}
+                        axisLine={false}
+                        tickLine={false}
+                        width={40}
+                      />
+
+                      <Line
+                        type="monotone"
+                        dataKey="value"
+                        stroke="#6ca6ff"
+                        strokeWidth={3}
+                        dot={{
+                          r: 4,
+                          fill: "#6ca6ff",
+                          stroke: "#fff",
+                          strokeWidth: 2,
+                        }}
+                        activeDot={{ r: 6 }}
+                      />
+                    </LineChart>
+                  </ResponsiveContainer>
+                </div>
               </div>
             </div>
           </div>
         </div>
-      </div>
+      )}
     </div>
   );
 }

--- a/src/pages/Login.js
+++ b/src/pages/Login.js
@@ -7,7 +7,7 @@ import { AuthContext } from "../context/AuthContext";
 
 function Login() {
   const navigate = useNavigate();
-  const { setUser } = useContext(AuthContext);
+  const { setUser, setActiveRole } = useContext(AuthContext);
   const [error, setError] = useState("");
 
   const [form, setForm] = useState({
@@ -31,6 +31,7 @@ function Login() {
       if (res.ok) {
         localStorage.setItem("token", data.token);
         setUser(data.user);
+        setActiveRole(data.user.role);
         navigate("/dashboard");
       } else {
         setError(data.message || data.error);

--- a/src/styles/Coach.css
+++ b/src/styles/Coach.css
@@ -1,95 +1,272 @@
-.search-container {
-    display: flex;
-    align-items: center;
-    gap: 10px; 
-    background-color:#848484;
-    padding:10px;
-    border-radius: 10px;    
-    width: fit-content;
-    margin-top:30px;
-    margin-left:15px;
+/* ============================================
+   Page Header
+   ============================================ */
+.coach-page-header {
+  text-align: center;
+  padding: 48px 20px 0;
 }
 
-.coach-container{
-    display:grid;
-    grid-auto-flow: column;
-    grid-template-columns: repeat(4, auto);
-    overflow-x: auto;
-    padding:50px;
-    padding-left: 50px;
-    padding-top:50px;
+.coach-page-header h1 {
+  font-size: 2.5rem;
+  font-weight: 700;
+  margin: 0 0 8px 0;
+  background: linear-gradient(135deg, #6ca6ff 0%, #a78bfa 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.coach-page-header p {
+  font-size: 1rem;
+  color: #a0a6b0;
+  margin: 0;
+}
+
+/* ============================================
+     Search Bar
+     ============================================ */
+.search-container {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 12px;
+  border-radius: 14px;
+  width: fit-content;
+  margin: 32px auto 0;
+  backdrop-filter: blur(10px);
 }
 
 .search-input {
-    width: 350px;
-    padding: 10px;
-    font-size: 16px;
-    border-radius: 10px;
-    border: none;        
-    outline: none; 
+  width: 340px;
+  padding: 10px 16px;
+  font-size: 15px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  outline: none;
+  background: rgba(255, 255, 255, 0.05);
+  color: #fff;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+
+.search-input::placeholder {
+  color: #6a6f78;
+}
+
+.search-input:focus {
+  border-color: rgba(108, 166, 255, 0.5);
+  background: rgba(255, 255, 255, 0.08);
 }
 
 .search-container .search-input {
-    background-color: #cfcfcf;
+  background: rgba(255, 255, 255, 0.05);
 }
 
 .filter-dropdown {
-    padding: 10px;
-    font-size: 16px;
-    background-color:transparent;
-    border-radius: 10px;
-    border: 3px solid #ccc;  
-    color: rgb(0, 0, 0);   
-    font-weight:700;
+  padding: 10px 14px;
+  font-size: 14px;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: #fff;
+  font-weight: 500;
+  cursor: pointer;
+  outline: none;
+  transition: border-color 0.15s ease;
+}
+
+.filter-dropdown:hover,
+.filter-dropdown:focus {
+  border-color: rgba(108, 166, 255, 0.4);
+}
+
+.filter-dropdown option {
+  background: #1a1d24;
+  color: #fff;
 }
 
 .search-button {
-    padding: 10px 16px;
-    font-size:16px;
-    background-color: #000000;
-    color: white;
-    border: none;
-    cursor: pointer;
-    border-radius: 10px;
+  padding: 10px 20px;
+  font-size: 14px;
+  font-weight: 600;
+  background: linear-gradient(135deg, #6ca6ff 0%, #4d8ae8 100%);
+  color: white;
+  border: none;
+  cursor: pointer;
+  border-radius: 10px;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
 }
 
 .search-button:hover {
-    background-color: #464646;
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(108, 166, 255, 0.3);
 }
 
-.coach-list{
-    display: flex;
-    align-items: center;
-    padding:10px;
-    border-radius: 10px;    
-    width: fit-content;
+/* ============================================
+     Status Messages (loading / error / empty)
+     ============================================ */
+.coach-status {
+  text-align: center;
+  padding: 40px;
+  opacity: 0.7;
+  font-size: 16px;
+  color: #a0a6b0;
 }
 
-.coach-card{
-    margin: 0;
-    display: flex;
-    flex-direction: column;
-    max-width: 300px;
-    text-decoration: none;
-    color: inherit;
+.coach-status.error {
+  color: #dc3545;
+  opacity: 1;
 }
 
-.coach-card h3{
-    margin: 5px 0 0;
-    font-size: 18px;
-    padding-bottom: 5px;
+/* ============================================
+     Coach Grid & Cards
+     ============================================ */
+.coach-container {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 24px;
+  padding: 40px;
+  max-width: 1400px;
+  margin: 0 auto;
 }
 
-.coach-card p{
-    margin:0;
-    font-size: 14px;
-    color:#999faa;
+.coach-card {
+  position: relative;
+  background: linear-gradient(
+    145deg,
+    rgba(255, 255, 255, 0.06) 0%,
+    rgba(255, 255, 255, 0.02) 100%
+  );
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  padding: 24px;
+  text-decoration: none;
+  color: inherit;
+  display: flex;
+  flex-direction: column;
+  transition: transform 0.25s ease, border-color 0.25s ease,
+    box-shadow 0.25s ease;
+  overflow: hidden;
+  backdrop-filter: blur(10px);
 }
 
-.avatar{
-    width: 100%;
-    height: 160px;
-    border-radius: 0;
-    object-fit: cover;
-    margin-bottom: 3px;
+.coach-card::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 80px;
+  background: linear-gradient(
+    135deg,
+    rgba(108, 166, 255, 0.15) 0%,
+    rgba(139, 92, 246, 0.1) 100%
+  );
+  z-index: 0;
+}
+
+.coach-card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(108, 166, 255, 0.4);
+  box-shadow: 0 12px 32px rgba(108, 166, 255, 0.15);
+}
+
+.coach-card .avatar {
+  width: 88px;
+  height: 88px;
+  border-radius: 50%;
+  object-fit: cover;
+  align-self: center;
+  border: 3px solid rgba(255, 255, 255, 0.1);
+  background: #1a1d24;
+  position: relative;
+  z-index: 1;
+  margin-top: 16px;
+  margin-bottom: 16px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+}
+
+.coach-card h3 {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #fff;
+  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  position: relative;
+  z-index: 1;
+}
+
+.verified-badge {
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.7rem;
+  color: #28a745;
+  margin-left: 0;
+}
+
+.coach-specialty {
+  margin: 6px 0 14px 0 !important;
+  font-size: 0.82rem !important;
+  color: #6ca6ff !important;
+  font-weight: 600;
+  text-align: center;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  position: relative;
+  z-index: 1;
+}
+
+.coach-card p {
+  margin: 0 0 16px 0;
+  font-size: 0.875rem;
+  color: #a0a6b0;
+  line-height: 1.5;
+  text-align: center;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  position: relative;
+  z-index: 1;
+  min-height: 3.9em;
+}
+
+.coach-card-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: auto;
+  padding-top: 16px;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  font-size: 0.8rem;
+  color: #8a909a;
+  position: relative;
+  z-index: 1;
+}
+
+.coach-card-footer span:last-child {
+  color: #fff;
+  font-weight: 700;
+  font-size: 0.95rem;
+}
+
+.coach-price {
+  color: #6ca6ff !important;
+}
+
+/* ============================================
+     Legacy list style (kept for compatibility)
+     ============================================ */
+.coach-list {
+  display: flex;
+  align-items: center;
+  padding: 10px;
+  border-radius: 10px;
+  width: fit-content;
 }

--- a/src/styles/CoachDetail.css
+++ b/src/styles/CoachDetail.css
@@ -1,76 +1,550 @@
-.coach-detail-page{
-    display:flex;
-    height:100vh;
+/* ============================================
+   Page
+   ============================================ */
+.cp-page {
+  min-height: 100vh;
+  background: #0d0f14;
+  padding: 32px 24px 80px;
+  color: #fff;
 }
 
-.button-container {
-    width: 200px;
-    display: flex;
-    flex-direction: column;
-    gap: 15px;
-    padding: 20px;
-    padding-top: 200px;
+.cp-status {
+  text-align: center;
+  padding: 120px 20px;
+  color: #a0a6b0;
 }
 
-.button-container button {
-    background: transparent;
-    border: none;
-    text-align: left;
-    cursor: pointer;
-    font-size: 14px;
-    padding: 8px 10px;
-    color: #838383;
-    transition: 0.2s;
+.cp-back {
+  display: inline-flex;
+  align-items: center;
+  color: #a0a6b0;
+  text-decoration: none;
+  font-size: 0.9rem;
+  padding: 8px 14px;
+  border-radius: 8px;
+  margin-bottom: 20px;
+  transition: color 0.15s ease, background 0.15s ease;
 }
 
-.button-container button:hover {
-    background: rgba(0, 0, 0, 0.05);
-    border-radius: 6px;
+.cp-back:hover {
+  color: #fff;
+  background: rgba(255, 255, 255, 0.04);
 }
 
-.coach-container2{
-    display: flex;
-    flex:1;
-    align-items: center;
-    height:600px;
-    gap: 20px;
-    padding: 10px;
-    border-radius: 10px;
+.cp-back-fallback {
+  display: inline-block;
+  margin-top: 20px;
+  color: #6ca6ff;
+  text-decoration: none;
 }
 
-.back-button{
-    text-decoration: none;
-    color: inherit;
+.cp-container {
+  max-width: 900px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
 }
 
-.coach-image {
-    display: flex;
+/* ============================================
+     Header card — cover + avatar + info + stats
+     ============================================ */
+.cp-header-card {
+  background: #161920;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 16px;
+  overflow: hidden;
 }
 
-.coach-image img {
-    width: 100%;
-    height: 450px;
-    object-fit: cover;
-    border-radius: 10px;
+.cp-cover {
+  height: 140px;
+  background: linear-gradient(135deg, #2a3553 0%, #3d2a5e 100%);
 }
 
-.line {
-  width: 400px;
-  height: 2px;
-  background-color: white;
-  margin: 25px 0;
+.cp-header-body {
+  padding: 0 28px 28px;
+  display: flex;
+  gap: 20px;
+  align-items: flex-start;
+  flex-wrap: wrap;
 }
 
-.coach-container h4{
-    padding-bottom:50px;
+.cp-avatar {
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 4px solid #161920;
+  background: #1a1d24;
+  margin-top: -60px;
+  flex-shrink: 0;
 }
 
-.coach-info {
-    max-width: 400px;
-    position:relative;
-    left:150px;
-    flex: 1;            
-    display: flex;
-    flex-direction: column;
-    color:white;
+.cp-header-main {
+  flex: 1;
+  min-width: 280px;
+  padding-top: 8px;
+}
+
+.cp-title-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin-bottom: 20px;
+}
+
+.cp-name {
+  margin: 0 0 4px 0;
+  font-size: 1.5rem;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.cp-verified {
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.7rem;
+  background: rgba(40, 167, 69, 0.12);
+  color: #34d058;
+  padding: 3px 10px;
+  border-radius: 12px;
+  font-weight: 500;
+  border: 1px solid rgba(40, 167, 69, 0.25);
+}
+
+.cp-subtitle {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #8a909a;
+}
+
+.cp-request-btn {
+  padding: 10px 22px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  background: #fff;
+  color: #0d0f14;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.15s ease, transform 0.15s ease;
+  white-space: nowrap;
+}
+
+.cp-request-btn:hover:not(:disabled) {
+  background: #e0e0e0;
+  transform: translateY(-1px);
+}
+
+.cp-request-btn:disabled {
+  background: rgba(255, 255, 255, 0.08);
+  color: #6a6f78;
+  cursor: not-allowed;
+}
+
+.cp-stats {
+  display: flex;
+  gap: 32px;
+  padding-top: 20px;
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
+  flex-wrap: wrap;
+}
+
+.cp-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.cp-stat-value {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #fff;
+}
+
+.cp-stat-label {
+  font-size: 0.75rem;
+  color: #8a909a;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+/* ============================================
+     Tabs
+     ============================================ */
+.cp-tabs {
+  display: flex;
+  gap: 4px;
+  background: #161920;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 10px;
+  padding: 4px;
+}
+
+.cp-tab {
+  flex: 1;
+  background: transparent;
+  border: none;
+  color: #8a909a;
+  padding: 10px 16px;
+  font-size: 0.9rem;
+  font-weight: 500;
+  border-radius: 7px;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.cp-tab:hover {
+  color: #fff;
+}
+
+.cp-tab.active {
+  background: rgba(255, 255, 255, 0.08);
+  color: #fff;
+}
+
+/* ============================================
+     Content cards
+     ============================================ */
+.cp-card {
+  background: #161920;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 14px;
+  padding: 24px;
+}
+
+.cp-card-title {
+  margin: 0 0 12px 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #fff;
+}
+
+.cp-bio {
+  margin: 0;
+  color: #c8cdd4;
+  line-height: 1.7;
+  font-size: 0.95rem;
+}
+
+.cp-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.cp-chip {
+  display: inline-block;
+  background: rgba(108, 166, 255, 0.1);
+  border: 1px solid rgba(108, 166, 255, 0.2);
+  color: #6ca6ff;
+  padding: 6px 14px;
+  border-radius: 8px;
+  font-weight: 500;
+  font-size: 0.85rem;
+}
+
+/* ============================================
+     Section headers (Packages tab)
+     ============================================ */
+.cp-section-header {
+  padding: 12px 4px 4px;
+}
+
+.cp-section-header h3 {
+  margin: 0 0 4px 0;
+  font-size: 1.15rem;
+  font-weight: 600;
+  color: #fff;
+}
+
+.cp-section-header p {
+  margin: 0;
+  color: #8a909a;
+  font-size: 0.9rem;
+}
+
+/* ============================================
+     Program cards (1/3/6 month)
+     ============================================ */
+.cp-programs-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+}
+
+@media (max-width: 760px) {
+  .cp-programs-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.cp-program-card {
+  position: relative;
+  background: #161920;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 14px;
+  padding: 24px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  transition: border-color 0.15s ease, transform 0.15s ease;
+}
+
+.cp-program-card:hover {
+  border-color: rgba(255, 255, 255, 0.12);
+  transform: translateY(-2px);
+}
+
+.cp-program-card.featured {
+  border-color: #6ca6ff;
+  background: linear-gradient(
+    180deg,
+    rgba(108, 166, 255, 0.08) 0%,
+    #161920 100%
+  );
+}
+
+.cp-program-badge {
+  position: absolute;
+  top: -10px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #6ca6ff;
+  color: #0d0f14;
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 3px 12px;
+  border-radius: 10px;
+  letter-spacing: 0.3px;
+}
+
+.cp-program-title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 500;
+  color: #8a909a;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.cp-program-price {
+  font-size: 2.25rem;
+  font-weight: 700;
+  color: #fff;
+  display: flex;
+  align-items: baseline;
+  gap: 4px;
+  line-height: 1;
+}
+
+.cp-program-currency {
+  font-size: 1.25rem;
+  font-weight: 500;
+  color: #8a909a;
+}
+
+.cp-program-period {
+  font-size: 0.85rem;
+  color: #8a909a;
+  font-weight: 400;
+  margin-left: 4px;
+}
+
+.cp-program-features {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  flex: 1;
+}
+
+.cp-program-features li {
+  color: #c8cdd4;
+  font-size: 0.88rem;
+  padding-left: 20px;
+  position: relative;
+  line-height: 1.5;
+}
+
+.cp-program-features li::before {
+  content: "✓";
+  position: absolute;
+  left: 0;
+  color: #6ca6ff;
+  font-weight: 600;
+}
+
+.cp-program-btn {
+  width: 100%;
+  padding: 11px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  background: rgba(255, 255, 255, 0.06);
+  color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.cp-program-btn:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.cp-program-card.featured .cp-program-btn {
+  background: #6ca6ff;
+  color: #0d0f14;
+  border-color: #6ca6ff;
+}
+
+.cp-program-card.featured .cp-program-btn:hover:not(:disabled) {
+  background: #5a95ee;
+}
+
+.cp-program-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* ============================================
+     Session booking card
+     ============================================ */
+.cp-booking-card {
+  background: #161920;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 14px;
+  padding: 24px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 24px;
+  flex-wrap: wrap;
+}
+
+.cp-booking-info {
+  flex: 1;
+  min-width: 260px;
+}
+
+.cp-booking-rate {
+  display: flex;
+  align-items: baseline;
+  gap: 4px;
+  margin-bottom: 8px;
+}
+
+.cp-booking-price {
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: #fff;
+}
+
+.cp-booking-unit {
+  font-size: 0.95rem;
+  color: #8a909a;
+}
+
+.cp-booking-desc {
+  margin: 0 0 16px 0;
+  color: #8a909a;
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.cp-booking-bundles {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.cp-bundle {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 10px;
+  padding: 10px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 100px;
+}
+
+.cp-bundle-count {
+  font-size: 0.75rem;
+  color: #8a909a;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+}
+
+.cp-bundle-price {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #fff;
+}
+
+.cp-bundle-save {
+  font-size: 0.7rem;
+  color: #34d058;
+  font-weight: 500;
+  margin-top: 2px;
+}
+
+.cp-booking-btn {
+  padding: 12px 24px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  background: #fff;
+  color: #0d0f14;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s ease, transform 0.15s ease;
+}
+
+.cp-booking-btn:hover:not(:disabled) {
+  background: #e0e0e0;
+  transform: translateY(-1px);
+}
+
+.cp-booking-btn:disabled {
+  background: rgba(255, 255, 255, 0.08);
+  color: #6a6f78;
+  cursor: not-allowed;
+}
+
+/* ============================================
+     Empty states
+     ============================================ */
+.cp-empty {
+  text-align: center;
+  padding: 60px 20px;
+}
+
+.cp-empty-icon {
+  font-size: 2.5rem;
+  margin-bottom: 12px;
+  opacity: 0.7;
+}
+
+.cp-empty h3 {
+  margin: 0 0 6px 0;
+  color: #fff;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.cp-empty p {
+  margin: 0 auto;
+  color: #8a909a;
+  max-width: 380px;
+  font-size: 0.9rem;
+  line-height: 1.5;
 }

--- a/src/styles/Dashboard.css
+++ b/src/styles/Dashboard.css
@@ -57,8 +57,7 @@
   );
   backdrop-filter: blur(14px);
   -webkit-backdrop-filter: blur(14px);
-  box-shadow:
-    0 10px 30px rgba(0, 0, 0, 0.22),
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.22),
     inset 0 1px 0 rgba(255, 255, 255, 0.03);
   color: white;
 }
@@ -461,4 +460,290 @@
   width: 40px;
   height: 40px;
   opacity: 0.9;
+}
+
+/* ============================================
+   COACH DASHBOARD
+   ============================================ */
+.coach-dash {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 32px 24px;
+}
+
+.coach-dash-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 24px;
+  margin-bottom: 32px;
+  flex-wrap: wrap;
+}
+
+.coach-dash-title {
+  margin: 0 0 6px 0;
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: #fff;
+}
+
+.coach-dash-subtitle {
+  margin: 0;
+  color: #8a909a;
+  font-size: 0.95rem;
+}
+
+.coach-dash-stats {
+  display: flex;
+  gap: 12px;
+}
+
+.coach-stat-pill {
+  background: #161920;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 12px;
+  padding: 12px 20px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  min-width: 100px;
+}
+
+.coach-stat-num {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #fff;
+}
+
+.coach-stat-lbl {
+  font-size: 0.7rem;
+  color: #8a909a;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.coach-dash-section {
+  margin-bottom: 36px;
+}
+
+.coach-section-head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.coach-section-head h2 {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #fff;
+}
+
+.coach-badge-red {
+  background: #dc3545;
+  color: #fff;
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 2px 10px;
+  border-radius: 12px;
+}
+
+.coach-dash-muted {
+  color: #8a909a;
+  font-size: 0.9rem;
+}
+
+/* Empty states */
+.coach-empty {
+  background: #161920;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 14px;
+  padding: 48px 20px;
+  text-align: center;
+}
+
+.coach-empty-icon {
+  font-size: 2.5rem;
+  margin-bottom: 8px;
+  opacity: 0.7;
+}
+
+.coach-empty h3 {
+  margin: 0 0 4px 0;
+  color: #fff;
+  font-size: 1rem;
+}
+
+.coach-empty p {
+  margin: 0;
+  color: #8a909a;
+  font-size: 0.9rem;
+}
+
+/* Request cards */
+.coach-req-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.coach-req-card {
+  background: #161920;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 14px;
+  padding: 20px;
+  display: flex;
+  gap: 16px;
+}
+
+.coach-req-avatar {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
+  background: #1a1d24;
+}
+
+.coach-req-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.coach-req-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+  margin-bottom: 14px;
+  flex-wrap: wrap;
+}
+
+.coach-req-name {
+  margin: 0 0 2px 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: #fff;
+}
+
+.coach-req-time {
+  margin: 0;
+  font-size: 0.8rem;
+  color: #8a909a;
+}
+
+.coach-req-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.coach-btn-approve,
+.coach-btn-reject {
+  padding: 8px 16px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  border-radius: 8px;
+  border: none;
+  cursor: pointer;
+  transition: background 0.15s ease, transform 0.15s ease;
+}
+
+.coach-btn-approve {
+  background: #28a745;
+  color: #fff;
+}
+
+.coach-btn-approve:hover {
+  background: #218838;
+  transform: translateY(-1px);
+}
+
+.coach-btn-reject {
+  background: rgba(220, 53, 69, 0.12);
+  color: #dc3545;
+  border: 1px solid rgba(220, 53, 69, 0.3);
+}
+
+.coach-btn-reject:hover {
+  background: rgba(220, 53, 69, 0.2);
+}
+
+.coach-req-survey {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 10px;
+  padding-top: 14px;
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.coach-req-field {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.coach-req-field-label {
+  font-size: 0.7rem;
+  color: #8a909a;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+}
+
+.coach-req-field-value {
+  font-size: 0.9rem;
+  color: #fff;
+}
+
+/* Client cards */
+.coach-clients-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 14px;
+}
+
+.coach-client-card {
+  background: #161920;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 14px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  text-align: center;
+}
+
+.coach-client-avatar {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  object-fit: cover;
+  background: #1a1d24;
+}
+
+.coach-client-card h4 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #fff;
+}
+
+.coach-client-since {
+  margin: 0;
+  font-size: 0.8rem;
+  color: #8a909a;
+}
+
+.coach-client-view {
+  margin-top: 8px;
+  padding: 8px 14px;
+  font-size: 0.8rem;
+  font-weight: 500;
+  background: rgba(255, 255, 255, 0.04);
+  color: #8a909a;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 8px;
+  cursor: not-allowed;
 }


### PR DESCRIPTION
## What
- Adds "My Coaches" section to the client dashboard
- Adds coach browsing page with coach cards
- Adds coach detail page with bio and package section
- Adds role-based header that shows different nav for coach vs client

## Notes for reviewers
- Package data on the coach detail page is **placeholder** — 
  backend wiring will come in a follow-up PR
- Role-based header checks user role from [wherever you're checking it] 
  and renders different menu items

## Testing
1. Log in as a client → dashboard shows "My Coaches" section
2. Navigate to browse coaches → cards render, clicking a coach opens detail page
3. Log in as a coach → header shows coach-specific nav